### PR TITLE
Fix macOS compilation

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -41,4 +41,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Fetch submodules
+      run: git submodule update --init
     - uses: actions/checkout@v4
 
     - name: Configure CMake

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v4
+
     - name: Fetch submodules
       run: git submodule update --init
-      
-    - uses: actions/checkout@v4
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
     - name: Fetch submodules
       run: git submodule update --init
+      
     - uses: actions/checkout@v4
 
     - name: Configure CMake

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Project exclude paths
 build*/
 coverage/
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .venv/
 .cache/
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .cache/
 compile_commands.json
 valgrind-out.txt
+*.lox.bin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/CMake-argp"]
+	path = externals/CMake-argp
+	url = https://github.com/alehaa/CMake-argp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "externals/CMake-argp"]
-	path = externals/CMake-argp
+[submodule "cmake-argp"]
+	path = externals/cmake-argp
 	url = https://github.com/alehaa/CMake-argp.git
 [submodule "externals/argp-standalone"]
 	path = externals/argp-standalone
-	url = https://github.com/ericonr/argp-standalone
+	url = https://github.com/tom42/argp-standalone

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "externals/CMake-argp"]
 	path = externals/CMake-argp
 	url = https://github.com/alehaa/CMake-argp.git
+[submodule "externals/argp-standalone"]
+	path = externals/argp-standalone
+	url = https://github.com/ericonr/argp-standalone

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/alehaa/CMake-argp.git
 [submodule "externals/argp-standalone"]
 	path = externals/argp-standalone
-	url = https://github.com/tom42/argp-standalone
+	url = https://github.com/lordofdestiny/argp-standalone.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "search.exclude": {
+        "externals" : true,
+        ".clangd" : true,
+        ".git*" : true
+    },
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ include(CTest)
 option(ENABLE_COVERAGE "Enable code coverage generation" NO)
 option(CLOX_NAN_BOXING "Enable NAN BOXING for stack values" YES)
 
-
 if(BUILD_TESTING)
   include(FetchCMocka)
   enable_testing()
@@ -31,6 +30,10 @@ if(result)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 else()
   message(WARNING "IPO is not supported: ${output}")
+endif()
+
+if(APPLE)
+  add_compile_definitions(IS_APPLE)
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors -Wpedantic -pedantic -Wall -Wextra")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 project(clox LANGUAGES C)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/cmake-argp/cmake")
 
 include(CheckIPOSupported)
 include(CTest)

--- a/apps/clox/args/CMakeLists.txt
+++ b/apps/clox/args/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/cmake-argp/cmake" "${CMAKE_MODULE_PATH}")
-
-find_package(argp REQUIRED)
-
 add_library(cloxargs OBJECT)
 
 target_sources(cloxargs
@@ -15,8 +11,17 @@ target_sources(cloxargs
       include/args.h
 )
 
-target_link_libraries(cloxargs PRIVATE argp)
+find_package(argp)
+if(ARGP_FOUND)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/externals/argp-standalone ${CMAKE_BINARY_DIR}/externals/argp-standalone)
+  target_compile_options(argp-standalone PRIVATE "-Wno-unused-parameter" "-Wno-pedantic" "-Wno-pointer-arith" "-Wno-missing-field-initializers")
+
+  set(ARGP_LIBRARIES argp-standalone)
+endif()
+
+target_link_libraries(cloxargs PRIVATE ${ARGP_LIBRARIES})
 
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
+ 

--- a/apps/clox/args/CMakeLists.txt
+++ b/apps/clox/args/CMakeLists.txt
@@ -13,8 +13,20 @@ target_sources(cloxargs
 
 find_package(argp)
 if(NOT ARGP_FOUND)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/externals/argp-standalone ${CMAKE_BINARY_DIR}/externals/argp-standalone)
-  target_compile_options(argp-standalone PRIVATE "-Wno-unused-parameter" "-Wno-pedantic" "-Wno-pointer-arith" "-Wno-missing-field-initializers")
+  add_subdirectory(
+    ${PROJECT_SOURCE_DIR}/externals/argp-standalone
+    ${CMAKE_BINARY_DIR}/externals/argp-standalone
+  )
+
+  target_compile_options(
+    argp-standalone
+    PRIVATE
+      "-Wno-missing-field-initializers"
+      "-Wno-unused-parameter"
+      "-Wno-pointer-arith"
+      "-Wno-pedantic"
+      "-Wno-cpp"
+  )
 
   set(ARGP_LIBRARIES argp-standalone)
   target_link_libraries(cloxargs PUBLIC ${ARGP_LIBRARIES})

--- a/apps/clox/args/CMakeLists.txt
+++ b/apps/clox/args/CMakeLists.txt
@@ -12,14 +12,13 @@ target_sources(cloxargs
 )
 
 find_package(argp)
-if(ARGP_FOUND)
+if(NOT ARGP_FOUND)
   add_subdirectory(${PROJECT_SOURCE_DIR}/externals/argp-standalone ${CMAKE_BINARY_DIR}/externals/argp-standalone)
   target_compile_options(argp-standalone PRIVATE "-Wno-unused-parameter" "-Wno-pedantic" "-Wno-pointer-arith" "-Wno-missing-field-initializers")
 
   set(ARGP_LIBRARIES argp-standalone)
+  target_link_libraries(cloxargs PUBLIC ${ARGP_LIBRARIES})
 endif()
-
-target_link_libraries(cloxargs PRIVATE ${ARGP_LIBRARIES})
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/apps/clox/args/CMakeLists.txt
+++ b/apps/clox/args/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/cmake-argp/cmake" "${CMAKE_MODULE_PATH}")
+
+find_package(argp REQUIRED)
+
 add_library(cloxargs OBJECT)
 
 target_sources(cloxargs
@@ -10,6 +14,8 @@ target_sources(cloxargs
     FILES
       include/args.h
 )
+
+target_link_libraries(cloxargs PRIVATE argp)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/apps/clox/args/include/args.h
+++ b/apps/clox/args/include/args.h
@@ -1,8 +1,9 @@
 #ifndef __CLOX2_ARGS_H__
 #define __CLOX2_ARGS_H__
 
-#include <argp.h>
 #include <stdbool.h>
+
+#include <argp.h>
 
 typedef enum {
     CMD_NONE,

--- a/apps/native/src/generate.c
+++ b/apps/native/src/generate.c
@@ -265,12 +265,36 @@ void generateModuleWrapperSource(FILE* file, NativeModule* module, const char* i
         generateFunctionWrapper(file, module, &module->functions[i]);
     }
 
-    fprintf(file, PREFIXED(NO_EXPORT)" void %sDefaultModuleOnLoad(void) { }\n", module->namePrefix, module->name);
-    fprintf(file, PREFIXED(EXPORT)" void onLoad(void) __attribute__((weak, alias(\"%sDefaultModuleOnLoad\")));\n", module->namePrefix, module->name);
-
-    fprintf(file, PREFIXED(NO_EXPORT)" void %sDefaultModuleOnUnload(void) { }\n", module->namePrefix, module->name);
-    fprintf(file, PREFIXED(EXPORT)" void onUnload(void) __attribute__((weak, alias(\"%sDefaultModuleOnUnload\")));\n", module->namePrefix, module->name);
     fprintf(file, "\n");
+
+    const char* defaultModuleOnLoadSuffix = "DefaultModuleOnLoad";
+    const char* defaultModuleOnUnloadSuffix = "DefaultModuleOnUnload";
+        
+    fprintf(file, PREFIXED(NO_EXPORT)" void %s%s(void) { }\n", module->namePrefix, module->name, defaultModuleOnLoadSuffix);
+    fprintf(file, PREFIXED(NO_EXPORT)" void %s%s(void) { }\n", module->namePrefix, module->name, defaultModuleOnUnloadSuffix);
+
+    fprintf(file, "#if defined(__APPLE__)\n");
+
+    fprintf(file, "\t" PREFIXED(EXPORT)" void onLoad(void);\n", module->namePrefix);
+    fprintf(file, "\t#pragma weak onLoad = %s%s\n", module->name, defaultModuleOnLoadSuffix);
+
+    fprintf(file, "\t" PREFIXED(EXPORT)" void onUnload(void);\n", module->namePrefix);
+    fprintf(file, "\t#pragma weak onUnload = %s%s\n", module->name, defaultModuleOnUnloadSuffix);
+
+    fprintf(file, "#else\n");
+
+    fprintf(
+        file,
+        "\t" PREFIXED(EXPORT)" void onLoad(void) __attribute__((weak, alias(\"%s%s\")));\n",
+        module->namePrefix, module->name, defaultModuleOnLoadSuffix
+    );
+    fprintf(
+        file,
+        "\t" PREFIXED(EXPORT)" void onUnload(void) __attribute__((weak, alias(\"%s%s\")));\n",
+        module->namePrefix, module->name, defaultModuleOnUnloadSuffix
+    );
+
+    fprintf(file, "#endif\n");
 
     generateFunctionMap(file, module);
 

--- a/apps/native/src/generate.c
+++ b/apps/native/src/generate.c
@@ -267,34 +267,21 @@ void generateModuleWrapperSource(FILE* file, NativeModule* module, const char* i
 
     fprintf(file, "\n");
 
-    const char* defaultModuleOnLoadSuffix = "DefaultModuleOnLoad";
-    const char* defaultModuleOnUnloadSuffix = "DefaultModuleOnUnload";
-        
-    fprintf(file, PREFIXED(NO_EXPORT)" void %s%s(void) { }\n", module->namePrefix, module->name, defaultModuleOnLoadSuffix);
-    fprintf(file, PREFIXED(NO_EXPORT)" void %s%s(void) { }\n", module->namePrefix, module->name, defaultModuleOnUnloadSuffix);
+    // Define default no-op implementations
+    fprintf(file, "static void onLoad_default(void) { }\n");
+    fprintf(file, "static void onUnload_default(void) { }\n\n");
 
-    fprintf(file, "#if defined(__APPLE__)\n");
-
-    fprintf(file, "\t" PREFIXED(EXPORT)" void onLoad(void);\n", module->namePrefix);
-    fprintf(file, "\t#pragma weak onLoad = %s%s\n", module->name, defaultModuleOnLoadSuffix);
-
-    fprintf(file, "\t" PREFIXED(EXPORT)" void onUnload(void);\n", module->namePrefix);
-    fprintf(file, "\t#pragma weak onUnload = %s%s\n", module->name, defaultModuleOnUnloadSuffix);
-
-    fprintf(file, "#else\n");
-
+    // Weak functions that can be overridden by user code
     fprintf(
         file,
-        "\t" PREFIXED(EXPORT)" void onLoad(void) __attribute__((weak, alias(\"%s%s\")));\n",
-        module->namePrefix, module->name, defaultModuleOnLoadSuffix
+        PREFIXED(EXPORT)" __attribute__((weak)) void onLoad(void) { onLoad_default(); }\n",
+        module->namePrefix
     );
     fprintf(
         file,
-        "\t" PREFIXED(EXPORT)" void onUnload(void) __attribute__((weak, alias(\"%s%s\")));\n",
-        module->namePrefix, module->name, defaultModuleOnUnloadSuffix
+        PREFIXED(EXPORT)" __attribute__((weak)) void onUnload(void) { onUnload_default(); }\n",
+        module->namePrefix
     );
-
-    fprintf(file, "#endif\n");
 
     generateFunctionMap(file, module);
 

--- a/cmake/CloxNative.cmake
+++ b/cmake/CloxNative.cmake
@@ -124,4 +124,9 @@ function(CloxNativeLibrary)
   target_compile_options(${TargetName} PRIVATE "-Wno-unused-parameter")
 
   target_link_libraries(${TargetName} PUBLIC cloximpl::api_native PRIVATE ${LinkLibs})
+
+  if(APPLE)
+    target_link_options(${TargetName} PRIVATE "-Wl,-undefined,dynamic_lookup")
+  endif()
+
 endfunction()

--- a/fib.lox
+++ b/fib.lox
@@ -18,9 +18,9 @@ class Fibo {
 }
 
 fun benchmark(target) {
-    var start = getTime();
+    var start = clock();
     var result = target();
-    var end = getTime();
+    var end = clock();
 
     print "Result: " + String(result);
     print "Time: " + String(end - start);

--- a/lib/common/include/common/arena.h
+++ b/lib/common/include/common/arena.h
@@ -4,7 +4,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if  defined(IS_APPLE)
 #define ARENA_ALIGNMENT  (alignof(max_align_t))
+#else
+#define ARENA_ALIGNMENT (alignof(size_t))
+#endif
 
 typedef struct {
     alignas(max_align_t) size_t capacity;
@@ -13,7 +17,6 @@ typedef struct {
 
 static_assert(
     alignof(arena_t) == ARENA_ALIGNMENT &&
-    sizeof(arena_t) == ARENA_ALIGNMENT &&
     sizeof(arena_t) % ARENA_ALIGNMENT == 0,
     "Arena object violates requirements"
 );

--- a/lib/common/include/common/arena.h
+++ b/lib/common/include/common/arena.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if  defined(IS_APPLE)
+#if !defined(IS_APPLE)
 #define ARENA_ALIGNMENT  (alignof(max_align_t))
 #else
 #define ARENA_ALIGNMENT (alignof(size_t))

--- a/lib/common/src/arena.c
+++ b/lib/common/src/arena.c
@@ -23,8 +23,10 @@
 typedef struct {
     size_t free : 1;
     size_t size : 8 * sizeof(size_t) - 1;
+#if !defined(IS_APPLE)
     // Insert padding to future proof the implementation for new features
     char padding[ARENA_ALIGNMENT - sizeof(size_t)];
+#endif
 } block_header_t;
 
 static_assert(

--- a/lib/module/math/src/math.c
+++ b/lib/module/math/src/math.c
@@ -9,9 +9,3 @@ double ludolphine_number(void) {
 double eulers_number(void) {
     return M_E;
 }
-
-#include <stdio.h>
-
-CLOXMATH_EXPORT void onLoad(void){
-    printf("MATH MODULE LOADED\n");
-}

--- a/lib/module/math/src/math.c
+++ b/lib/module/math/src/math.c
@@ -9,3 +9,9 @@ double ludolphine_number(void) {
 double eulers_number(void) {
     return M_E;
 }
+
+#include <stdio.h>
+
+CLOXMATH_EXPORT void onLoad(void){
+    printf("MATH MODULE LOADED\n");
+}

--- a/lib/scanner/common/test/CMakeLists.txt
+++ b/lib/scanner/common/test/CMakeLists.txt
@@ -17,3 +17,7 @@ target_link_libraries(
     cloxcommon
     cloxscanner_common
 )
+
+if(APPLE)
+  target_link_options(TestScannerCommon PRIVATE "-Wl,-undefined,dynamic_lookup")
+endif()


### PR DESCRIPTION
This project was previously not able to be compiled on macOS due to two main issues:
- On macOS standard GNU argp library is not available
- The native library bindings relied on `__attribute__(weak, (alias("aliasedName")))` to allow `onLoad()`/`onUnload()` events in clox native libs

To resolve argp library support, two things were utilized:
1. `cmake-argp` library that enables detection of `argp` library through `find_package`
2. [tom42/argp-standalone](https://github.com/tom42/argp-standalone) has been forked to add macOS support

To resolve event binding, different pattern was used for default versions of event methods. Consequently, client libraries need to use `<LIBNAME>_EXPORT` macros in order to properly define these overloads.